### PR TITLE
From python27 to python310

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,19 @@
+# This file specifies files that are *not* uploaded to Google Cloud
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Python pycache:
+__pycache__/
+# Ignored by the build system
+/setup.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 #pre-compiled python binaries (from dev_appserver.py)
 *.pyc
+*.code-workspace

--- a/README.md
+++ b/README.md
@@ -171,7 +171,30 @@ Search for a property within the city of Appleton using the street address.
 ```
 
 ## Deployment notes (for the maintainer)
+Use miniconda/conda within VSCode to create a venv for you and the tell VSCode to use it for the below.
 ```
+Assorted pre-requisites:
+
+# Python 2 to 3 tool
+$ pip install modernize
+$ python-modernize -w appletonapi.py
+
+# Googly dev server tools
+$ sudo apt-get update && sudo apt-get install google-cloud-sdk-skaffold google-cloud-sdk-bigtable-emulator google-cloud-sdk-anthos-auth google-cloud-sdk-log-streaming google-cloud-sdk-pubsub-emulator google-cloud-sdk google-cloud-sdk-terraform-tools google-cloud-sdk-cbt google-cloud-sdk-harbourbridge google-cloud-sdk-minikube google-cloud-sdk-spanner-emulator google-cloud-sdk-datastore-emulator google-cloud-sdk-app-engine-python-extras google-cloud-sdk-kpt google-cloud-sdk-kubectl-oidc google-cloud-sdk-package-go-module google-cloud-sdk-cloud-build-local google-cloud-sdk-local-extract google-cloud-sdk-app-engine-go google-cloud-sdk-app-engine-python google-cloud-sdk-app-engine-java google-cloud-sdk-app-engine-grpc google-cloud-sdk-gke-gcloud-auth-plugin google-cloud-sdk-config-connector google-cloud-sdk-nomos google-cloud-sdk-firestore-emulator kubectl google-cloud-sdk-cloud-run-proxy
+
+# More Googly bits
+$ pip install --upgrade gcloud
+$ pip install --upgrade google-api-python-client
+$ pip install google-cloud
+
+# Install local deps
+$ pip install -r requirements.txt
+
+# Run Googly dev server
+$ dev_appserver.py --dev_appserver_log_level debug --application appletonapi .
+
+$ gcloud app logs tail -s default
+
 $ gcloud app deploy --version 3-3 --no-promote
 ```
 ## Deprecated API versions.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,11 @@ Search for a property within the city of Appleton using the street address.
     }
 ]
 ```
+
+## Deployment notes (for the maintainer)
+```
+$ gcloud app deploy --version 3-3 --no-promote
+```
 ## Deprecated API versions.
 
 In order to reduce client breakage due to changes in the API, it is best to define the API version number in your calls. This way you will have time to refactor your client to work with new API changes.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Apps that allow you to lookup recycling pickup schedule for the current week:
 * [Is it recycling week in Appleton?](https://github.com/dhmncivichacks/isitrecycling) - web app
 * [Civic Hack API Locator](https://github.com/mrosack/civic-hack-api-locator) - Not a client, but an API discovery/contract project to which AppletonAPI will attempt to adhere to
 
-## API v3.2.0 (current)
+## API v3.3.0 (current)
 
 #### Search
 
@@ -28,7 +28,7 @@ Search for a property within the city of Appleton using the street address.
 
 **Returns**: JSON result consisting of a list of possible property ids.
 
-**Example**: http://3-2.appletonapi.appspot.com/search?q=121%20Douglas%20St (street address for the Appleton Makerspace)
+**Example**: http://3-3.appletonapi.appspot.com/search?q=121%20Douglas%20St (street address for the Appleton Makerspace)
 
 ```
 [
@@ -58,7 +58,7 @@ Search for a property within the city of Appleton using the street address.
 
 **Returns**: JSON result containing the majority of data available on my.appleton.org for that property.
 
-**Example**: http://3-2.appletonapi.appspot.com/property/315173204 (property key for the [Appleton Makerspace](http://appletonmakerspace.org))
+**Example**: http://3-3.appletonapi.appspot.com/property/315173204 (property key for the [Appleton Makerspace](http://appletonmakerspace.org))
 
 ```
 [

--- a/app.yaml
+++ b/app.yaml
@@ -1,15 +1,12 @@
-runtime: python27
-api_version: 1
-threadsafe: true
+runtime: python310
 
 handlers:
 - url: /favicon\.ico
   static_files: favicon.ico
   upload: favicon\.ico
 - url: .*
-  script: appletonapi.app
+  script: main.app
 
-libraries:
-- name: lxml
-  version: latest
-
+#libraries:
+#- name: lxml
+#  version: latest

--- a/main.py
+++ b/main.py
@@ -32,33 +32,37 @@ app = Flask(__name__)
 
 DATE_FORMAT = "%Y-%m-%d"
 
-_digits = re.compile('\d')
-def contains_digits(d):
+_digits = re.compile(r'\d')
+def contains_digits(maybe_digits):
     '''Decide if we have numbers.'''
-    return bool(_digits.search(d))
+    return bool(_digits.search(maybe_digits))
 
 
 def extracttagvalues(line):
     '''Parse html stuff.'''
-    m = re.search('(?<=value\=\").*?([^\'" >]+)', line)
-    if m:
-        return re.split('value="', m.group(0))[0]
+    maybe_match = re.search(r'(?<=value\=\").*?([^\'" >]+)', line)
+    if maybe_match:
+        return re.split('value="', maybe_match.group(0))[0]
+    return None
 
 
 def sanitizeinputwords(rawinput):
     '''Hacky regex to strip ugly input.'''
-    m = re.search('^\w+$', rawinput)
-    if m:
-        return m.group(0)
+    maybe_match = re.search(r'^\w+$', rawinput)
+    if maybe_match:
+        return maybe_match.group(0)
+    return None
 
 
 @app.route('/property/<int:propkey>')
 class PropertyHandler():
     '''Calls coming in with a propkey.'''
     def get(self, propkey):
+        '''Get'''
         return self.write_response(self.execute(propkey))
 
     def execute(self, propkey):
+        '''Execute'''
         propkey = sanitizeinputwords(propkey)
         detailurl = "http://my.appleton.org/Propdetail.aspx?PropKey=" + str(propkey)
         datagroups = []

--- a/main.py
+++ b/main.py
@@ -21,12 +21,11 @@ import logging
 import re
 
 import inflect
-import lxml.etree
-import lxml.html
 import requests
 import streetaddress
 
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
+from lxml import etree, html
 
 app = Flask(__name__)
 
@@ -38,27 +37,19 @@ def contains_digits(maybe_digits):
     return bool(_digits.search(maybe_digits))
 
 
-def extracttagvalues(line):
-    '''Parse html stuff.'''
-    maybe_match = re.search(r'(?<=value\=\").*?([^\'" >]+)', line)
-    if maybe_match:
-        return re.split('value="', maybe_match.group(0))[0]
-    return None
-
-
 @app.route('/property/<int:propkey>')
 def property_handler(propkey):
     '''Calls coming in with a propkey.'''
     detailurl = "http://my.appleton.org/Propdetail.aspx?PropKey=" + str(propkey)
     datagroups = []
     try:
-        docroot = lxml.html.fromstring(requests.get(detailurl, timeout=15).content)
+        docroot = html.fromstring(requests.get(detailurl, timeout=15).content)
         tables = docroot.xpath("//table[@class='t1']")
         for table in tables:
             ths = table.xpath("./tr/th")  # assuming single <th> per table
             for th in ths:
                 if th is not None:
-                    lxml.etree.strip_tags(th, 'a', 'b', 'br', 'span', 'strong')
+                    etree.strip_tags(th, 'a', 'b', 'br', 'span', 'strong')
                     if th.text:
                         thkey = re.sub('\W', '', th.text).lower()  # nospaces all lower
                         datagroups.append(thkey)
@@ -69,7 +60,7 @@ def property_handler(propkey):
                             tds = table.xpath("./tr/td")
                             if tds is not None:
                                 for td in tds:
-                                    lxml.etree.strip_tags(td, 'a', 'b', 'br', 'span', 'strong')
+                                    etree.strip_tags(td, 'a', 'b', 'br', 'span', 'strong')
                                     businesslist.append(td.text.strip())
                             logging.debug("businesslist: " + str(businesslist))
                         datadict = {}
@@ -77,7 +68,7 @@ def property_handler(propkey):
                         tds = table.xpath("./tr/td")
                         if tds is not None:
                             for td in tds:
-                                lxml.etree.strip_tags(td, 'a', 'b', 'br', 'span', 'strong')
+                                etree.strip_tags(td, 'a', 'b', 'br', 'span', 'strong')
                                 if tdcounter == 0:
                                     tdkey = re.sub('\W', '', td.text).lower() if td.text else ''
                                     tdcounter += 1
@@ -97,95 +88,100 @@ def property_handler(propkey):
 
 
 @app.route('/search')
-class SearchHandler():
+def search_handler():
     '''
     The ugliest hack here (and only real value-add of the whole thing).
     Parse .aspx forms and get back "useful" data.
     '''
-    def get(self):
-        '''Get'''
-        return self.write_response(self.execute(self.request.get('q'), str(self.request.headers['User-Agent'])))
+    # Google maps geolocation appends 'USA' but the address parser can't cope
+    search_input = request.args['q']
+    search_input = search_input.replace('USA','')
+    addr = streetaddress.parse(search_input)
+    if addr is None:
+        # Since we are so tightly coupled with Appleton data,
+        # let's just pacify the address parser.
+        addr = streetaddress.parse(search_input + ' Appleton, WI')
+    housenumber = addr['number']
+    # Handle upstream requirement of "Fifth" not "5th"
+    inflect_instance = inflect.engine()
+    if contains_digits(addr['street']):
+        street = inflect_instance.number_to_words(addr['street'])
+    else:
+        street = addr['street']
 
-    def execute(self, search_input, user_agent):
-        '''Execute'''
-        # Google maps geolocation appends 'USA' but the address parser can't cope
-        search_input = search_input.replace('USA','')
-        addr = streetaddress.parse(search_input)
-        if addr is None:
-            # Since we are so tightly coupled with Appleton data,
-            # let's just pacify the address parser.
-            addr = streetaddress.parse(search_input + ' Appleton, WI')
-        housenumber = addr['number']
-        # Handle upstream requirement of "Fifth" not "5th"
-        inflect_instance = inflect.engine()
-        if contains_digits(addr['street']):
-            street = inflect_instance.number_to_words(addr['street'])
-        else:
-            street = addr['street']
+    if not housenumber and not street:
+        return { 'error' : 'Give me *SOMETHING* to search for.'}
 
-        if not housenumber and not street:
-            return { 'error' : 'Give me *SOMETHING* to search for.'}
+    try:
+        foo = requests.get('http://my.appleton.org/', timeout=15).text
+        foo_parser = etree.HTMLParser()
+        foo_tree = etree.fromstring(foo, foo_parser)
+        allresults = []
+        #print(foo)
+        view_state = foo_tree.xpath("//input[@name='__VIEWSTATE']/@value")[0]
+        event_validation = foo_tree.xpath("//input[@name='__EVENTVALIDATION']/@value")[0]
 
-        try:
-            response = requests.get('http://my.appleton.org/', timeout=15).content
-            for line in response:
-                if "__VIEWSTATE\"" in line:
-                    vs = extracttagvalues(line)
-                if "__EVENTVALIDATION\"" in line:
-                    ev = extracttagvalues(line)
-                    formvalues = {
-                        '__EVENTTARGET': '',
-                        '__EVENTARGUMENT': '',
-                        '__VIEWSTATE': vs,
-                        '__EVENTVALIDATION': ev,
-                        'ctl00$myappletonContent$txtStreetNumber': housenumber,
-                        'ctl00$myappletonContent$txtStreetName': street,
-                        'ctl00$myappletonContent$btnSubmit': 'Submit'}
-                    headers = {
-                        'User-Agent': user_agent,
-                        'Referer': 'http://my.appleton.org/default.aspx',
-                        'Accept': 'text/html,application/xhtml+xml,application/xml'
-                    }
-                    #FIXME This is going to hurt.  was "urllib2" >>> now make it "requests".
-                    data = six.moves.urllib.parse.urlencode(formvalues)
-                    req = six.moves.urllib.request.Request("http://my.appleton.org/default.aspx", data, headers)
-                    response = six.moves.urllib.request.urlopen(req)
-                    allresults = []
-                    # Example of the HTML returned...
-                    # <a id="ctl00_myappletonContent_searchResults_ctl03_PropKey"
-                    # href="Propdetail.aspx?PropKey=312039300&amp;Num=100">312039300  </a>
-                    #                  </td><td>100</td><td>E WASHINGTON           ST  </td>
-                    for pline in response:
-                        if "Propdetail.aspx?PropKey=" in pline:
-                            searchresult = []
-                            maybe_propkey_match = re.search(r'(?<=PropKey\=).*(?=&)', pline)
-                            if maybe_propkey_match:
-                                searchresult.append(
-                                    re.split('PropKey=', maybe_propkey_match.group(0))[0]
-                                    )
-                            maybe_td_match = re.findall(r'(?s)<td>(.*?)</td>', next(response))
-                            if maybe_td_match:
-                                # this removes whitespace and Title Cases the address
-                                # given: <td>1200</td><td>W WISCONSIN    AVE </td>
-                                # returns: ['1200', 'W Wisconsin Ave']
-                                address = [
-                                    ' '.join(t.split()).strip().title() for t in maybe_td_match
-                                    ]
-                                searchresult.append(address[0]) #Number
-                                # Thank you Dan Gabrielson <dan.gabrielson@gmail.com> and
-                                # Matt Everson https://github.com/matteverson
-                                # for your help at 2015 Appleton Civic Hackathon!
-                                # This closes https://github.com/mikeputnam/appletonapi/issues/5
-                                label = ' '
-                                for chunk in address[1:]:
-                                    label += chunk + ' '
-                                searchresult.append(label.strip())
-                            allresults.append(searchresult)
+        formvalues = {
+            '__EVENTTARGET': '',
+            '__EVENTARGUMENT': '',
+            '__VIEWSTATE': view_state,
+            '__EVENTVALIDATION': event_validation,
+            'ctl00$myappletonContent$txtStreetNumber': housenumber,
+            'ctl00$myappletonContent$txtStreetName': street,
+            'ctl00$myappletonContent$btnSubmit': 'Submit'}
+        headers = {
+            'User-Agent': request.headers['User-Agent'],
+            'Referer': 'http://my.appleton.org/default.aspx',
+            'Accept': 'text/html,application/xhtml+xml,application/xml'
+        }
+        response = requests.post(
+            "http://my.appleton.org/default.aspx",
+            headers=headers,
+            data=formvalues,
+            timeout=15
+            )
+        #print(response.text)
+        res_parser = etree.HTMLParser()
+        res_tree = etree.fromstring(response.text, res_parser)
+        # Example of the HTML returned...
+        # <a id="ctl00_myappletonContent_searchResults_ctl03_PropKey"
+        # href="Propdetail.aspx?PropKey=312039300&amp;Num=100">312039300  </a>
+        #                  </td><td>100</td><td>E WASHINGTON           ST  </td>
+        searchresult = []
+        stripped_propkey = res_tree.xpath("//a[contains(@id, 'ctl00_myappletonContent_searchResults_ctl03_PropKey')]/text()")[0].strip()
+        searchresult.append(stripped_propkey)
+        # for pline in response:
+        #     if "Propdetail.aspx?PropKey=" in pline:
+        #         searchresult = []
+        #         maybe_propkey_match = re.search(r'(?<=PropKey\=).*(?=&)', pline)
+        #         if maybe_propkey_match:
+        #             searchresult.append(
+        #                 re.split('PropKey=', maybe_propkey_match.group(0))[0]
+        #                 )
+        #         maybe_td_match = re.findall(r'(?s)<td>(.*?)</td>', next(response))
+        #         if maybe_td_match:
+        #             # this removes whitespace and Title Cases the address
+        #             # given: <td>1200</td><td>W WISCONSIN    AVE </td>
+        #             # returns: ['1200', 'W Wisconsin Ave']
+        #             address = [
+        #                 ' '.join(t.split()).strip().title() for t in maybe_td_match
+        #                 ]
+        #             searchresult.append(address[0]) #Number
+        #             # Thank you Dan Gabrielson <dan.gabrielson@gmail.com> and
+        #             # Matt Everson https://github.com/matteverson
+        #             # for your help at 2015 Appleton Civic Hackathon!
+        #             # This closes https://github.com/mikeputnam/appletonapi/issues/5
+        #             label = ' '
+        #             for chunk in address[1:]:
+        #                 label += chunk + ' '
+        #             searchresult.append(label.strip())
+        #         allresults.append(searchresult)
+        allresults.append(searchresult)
 
-            return { 'result' : allresults }
-        except RuntimeError as err:
-            logging.error('SEARCH FAIL! my.appleton.org up? scrape assumptions still valid?')
-            return { 'error' : "Cannot search :( <br/>" + str(err) }
+        return { 'result' : allresults }
+    except RuntimeError as err:
+        logging.error('SEARCH FAIL! my.appleton.org up? scrape assumptions still valid?')
+        return { 'error' : "Cannot search :( <br/>" + str(err) }
 
 
 @app.route('/garbagecollection')
@@ -204,8 +200,7 @@ class GarbageCollectionHandler():
         collection_days = []
 
         if len(search_response['result']) > 0:
-            prop_handler = PropertyHandler()
-            prop_response = prop_handler.execute(search_response['result'][0][0])
+            prop_response = property_handler(search_response['result'][0][0])
             if 'error' in prop_response:
                 return prop_response
 
@@ -271,4 +266,3 @@ def main_handler():
 </html>
     """
     return indexhtml
-

--- a/main.py
+++ b/main.py
@@ -73,7 +73,8 @@ def property_handler(propkey):
                                     tdvalue = td.text.strip().title() if td.text else ''
                                     tdvalue = " ".join(tdvalue.split())  # remove extra whitespace
                                     tdcounter = 0
-                                    # when the source tr + td are commented out lxml still sees them. PREVENT!
+                                    # when the source tr + td are
+                                    # commented out lxml still sees them. PREVENT!
                                     if tdkey == '' and tdvalue == '':
                                         break
                                     else:
@@ -181,11 +182,16 @@ def garbage_collection_handler():
     collection_days = []
 
     addr = request.args['addr']
-    search_response = requests.get('http://3-3.appletonapi.appspot.com/search?q=' + addr, timeout=15)
+    search_response = requests.get(
+        'http://3-3.appletonapi.appspot.com/search?q=' + addr, timeout=15
+    )
     search_list = search_response.json()
 
     # Let's just use the first result ¯\_(ツ)_/¯
-    prop_response = requests.get('http://3-3.appletonapi.appspot.com/property/' + search_list['result'][0][0], timeout=15)
+    prop_response = requests.get(
+        'http://3-3.appletonapi.appspot.com/property/' + search_list['result'][0][0],
+        timeout=15
+    )
     property_data = prop_response.json()
 
     garbage_day = property_data['result'][1]['garbageday']

--- a/main.py
+++ b/main.py
@@ -265,11 +265,9 @@ class GarbageCollectionHandler():
 
 
 @app.route('/')
-class MainHandler():
+def main_handler():
     '''The index / of appletonapi.appspot.com.'''
-    def get(self):
-        '''Get'''
-        indexhtml = """
+    indexhtml = """
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -286,8 +284,8 @@ class MainHandler():
 <p><a href="https://github.com/dhmncivichacks/appletonapi">Documentation and source code available on Github.</a></p>
 </body>
 </html>
-        """
-        self.response.out.write(indexhtml)
+    """
+    return indexhtml
 
 
 # app = webapp2.WSGIApplication(

--- a/main.py
+++ b/main.py
@@ -272,21 +272,3 @@ def main_handler():
     """
     return indexhtml
 
-
-# app = webapp2.WSGIApplication(
-#     [
-#         ('/', MainHandler),
-#         (r'/property/(\d+)', PropertyHandler),
-#         ('/search', SearchHandler),
-#         ('/garbagecollection', GarbageCollectionHandler)
-#     ], debug=True)
-
-
-# def main():
-#     # Set the logging level in the main function
-#     logging.getLogger().setLevel(logging.DEBUG)
-#     webapp.util.run_wsgi_app(app)
-
-
-# if __name__ == '__main__':
-#     main()

--- a/main.py
+++ b/main.py
@@ -155,18 +155,23 @@ def search_handler():
         fields_per_record = 5
         record_list = [clean_table_td_list[n:n+fields_per_record] for n in range(0, len(clean_table_td_list), fields_per_record)]
 
-        for field in record_list:
+        for record in record_list:
             # the zeroth position is always empty. discard it.
-            del field[0]
+            del record[0]
+
+            # Embarassing hack for cases where this tuple is ''
+            # but we want an orderly concatenation later.
+            if record[3] == '':
+                record[3] = '_'
 
             # 0 is the propkey
             # 1 is the house number
             # 2 is the street name
             # 3 is the unit number
             searchresult.append([
-                field[0],
-                field[1],
-                field[2] + ' ' + field[3]    # FIXME if there is no UNIT...  line 168, in search_handler field[2] + ' ' + field[3]  IndexError: list index out of range
+                record[0],
+                record[1],
+                record[2] + ' ' + record[3]
             ])
 
         return jsonify({ 'result' : searchresult })

--- a/main.py
+++ b/main.py
@@ -245,7 +245,7 @@ class GarbageCollectionHandler():
         }[string_day]
 
 
-
+@app.route('/')
 class MainHandler():
     '''The index / of appletonapi.appspot.com.'''
     def get(self):

--- a/main.py
+++ b/main.py
@@ -54,7 +54,8 @@ def property_handler(propkey):
                         thkey = re.sub('\W', '', th.text).lower()  # nospaces all lower
                         datagroups.append(thkey)
                         if th.text.strip() == "Businesses":
-                            logging.debug("found Business <th>")
+                            logging.info("found Business <th>")
+                            print("found Business <th>")
                             tdkey = "businesses"
                             businesslist = []
                             tds = table.xpath("./tr/td")
@@ -120,7 +121,6 @@ def search_handler():
         #print(foo)
         view_state = foo_tree.xpath("//input[@name='__VIEWSTATE']/@value")[0]
         event_validation = foo_tree.xpath("//input[@name='__EVENTVALIDATION']/@value")[0]
-
         formvalues = {
             '__EVENTTARGET': '',
             '__EVENTARGUMENT': '',
@@ -148,8 +148,17 @@ def search_handler():
         # href="Propdetail.aspx?PropKey=312039300&amp;Num=100">312039300  </a>
         #                  </td><td>100</td><td>E WASHINGTON           ST  </td>
         searchresult = []
+        print(res_tree.xpath("//table[@id='ctl00_myappletonContent_searchResults']/tr[position()>1 and position()<last()]/td/a/text()") )
+
+        # Working but only gets the first propkey.
         stripped_propkey = res_tree.xpath("//a[contains(@id, 'ctl00_myappletonContent_searchResults_ctl03_PropKey')]/text()")[0].strip()
-        searchresult.append(stripped_propkey)
+        if stripped_propkey:
+            searchresult.append(stripped_propkey)
+            address_list = res_tree.xpath("//td/text()")
+            for item in address_list:
+                pass
+                #print(item.strip())
+
         # for pline in response:
         #     if "Propdetail.aspx?PropKey=" in pline:
         #         searchresult = []

--- a/main.py
+++ b/main.py
@@ -110,12 +110,11 @@ def search_handler():
         return { 'error' : 'Give me *SOMETHING* to search for.'}
 
     try:
-        foo = requests.get('http://my.appleton.org/', timeout=15).text
-        foo_parser = etree.HTMLParser()
-        foo_tree = etree.fromstring(foo, foo_parser)
-        #print(foo)
-        view_state = foo_tree.xpath("//input[@name='__VIEWSTATE']/@value")[0]
-        event_validation = foo_tree.xpath("//input[@name='__EVENTVALIDATION']/@value")[0]
+        initial_page = requests.get('http://my.appleton.org/', timeout=15).text
+        initial_page_parser = etree.HTMLParser()
+        initial_page_tree = etree.fromstring(initial_page, initial_page_parser)
+        view_state = initial_page_tree.xpath("//input[@name='__VIEWSTATE']/@value")[0]
+        event_validation = initial_page_tree.xpath("//input[@name='__EVENTVALIDATION']/@value")[0]
         formvalues = {
             '__EVENTTARGET': '',
             '__EVENTARGUMENT': '',

--- a/main.py
+++ b/main.py
@@ -28,6 +28,8 @@ import streetaddress
 
 from flask import Flask, jsonify
 
+app = Flask(__name__)
+
 DATE_FORMAT = "%Y-%m-%d"
 
 _digits = re.compile('\d')
@@ -269,7 +271,6 @@ class MainHandler():
         """
         self.response.out.write(indexhtml)
 
-app = Flask(__name__)
 
 # app = webapp2.WSGIApplication(
 #     [

--- a/main.py
+++ b/main.py
@@ -17,7 +17,6 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 from __future__ import absolute_import
 from datetime import datetime, timedelta
 
-import logging
 import re
 
 import inflect
@@ -54,8 +53,6 @@ def property_handler(propkey):
                         thkey = re.sub('\W', '', th.text).lower()  # nospaces all lower
                         datagroups.append(thkey)
                         if th.text.strip() == "Businesses":
-                            logging.info("found Business <th>")
-                            print("found Business <th>")
                             tdkey = "businesses"
                             businesslist = []
                             tds = table.xpath("./tr/td")
@@ -63,7 +60,6 @@ def property_handler(propkey):
                                 for td in tds:
                                     etree.strip_tags(td, 'a', 'b', 'br', 'span', 'strong')
                                     businesslist.append(td.text.strip())
-                            logging.debug("businesslist: " + str(businesslist))
                         datadict = {}
                         tdcounter = 0
                         tds = table.xpath("./tr/td")
@@ -174,7 +170,7 @@ def search_handler():
 
         return { 'result' : searchresult }
     except RuntimeError as err:
-        logging.error('SEARCH FAIL! my.appleton.org up? scrape assumptions still valid?')
+        print('SEARCH FAIL! my.appleton.org up? scrape assumptions still valid?')
         return { 'error' : "Cannot search :( <br/>" + str(err) }
 
 

--- a/main.py
+++ b/main.py
@@ -117,7 +117,6 @@ def search_handler():
         foo = requests.get('http://my.appleton.org/', timeout=15).text
         foo_parser = etree.HTMLParser()
         foo_tree = etree.fromstring(foo, foo_parser)
-        allresults = []
         #print(foo)
         view_state = foo_tree.xpath("//input[@name='__VIEWSTATE']/@value")[0]
         event_validation = foo_tree.xpath("//input[@name='__EVENTVALIDATION']/@value")[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+lxml
+Flask
+jsonify
+inflect
+streetaddress

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ lxml
 Flask
 jsonify
 inflect
+requests
 streetaddress


### PR DESCRIPTION
Google is finally refusing to run ancient python2 stuff on Google App Engine.  This PR takes us from python2x to python310.

- Adds some more dev docs.
- Got a little slower(~150ms) with the introduction of more usage of the lxml parser in places that were previously just regex-ing against static html. Not ideal, but simpler python.
- Most of the remaining changes are just updating the project to the latest Google project stuff.
- Tested all the routes, confirmed working cases and non-working cases. 
- May have found a bug in the [Android client](https://github.com/dhmncivichacks/isitrecyclingweek-android) in the address search logic not alerting Address not found, but can't be arsed to fix it right now.